### PR TITLE
native packages for arch

### DIFF
--- a/bin/sparrowdo
+++ b/bin/sparrowdo
@@ -407,6 +407,7 @@ elif [[ "$os" =~ "archlinux" ]]; then
 
     pacman -Sy
 
+    pacman -S --noconfirm -q guile 
 
     if ! which perl 2>/dev/null; then
       pacman -S --noconfirm -q perl
@@ -420,7 +421,7 @@ elif [[ "$os" =~ "archlinux" ]]; then
       pacman -S --noconfirm -q make 
     fi
 
-    pacman -S --noconfirm -q guile perl-clone perl-config-tiny perl-yaml perl-test-yaml perl-test-base perl-spiffy perl-algorithm-diff perl-text-diff perl-json perl-try-tiny perl-capture-tiny perl-file-sharedir perl-file-sharedir-install perl-module-build-tiny perl-extutils-installpaths perl-extutils-config perl-extutils-helpers perl-class-inspector
+    pacman -S --noconfirm -q perl-clone perl-config-tiny perl-yaml perl-test-yaml perl-test-base perl-spiffy perl-algorithm-diff perl-text-diff perl-json perl-try-tiny perl-capture-tiny perl-file-sharedir perl-file-sharedir-install perl-module-build-tiny perl-extutils-installpaths perl-extutils-config perl-extutils-helpers perl-class-inspector
 
     cpanm -q Outthentic Sparrow || echo "Some error occurs. Try to take the system upgrade of your server: run 'pacman -Syu' on the target machine and then run bootstrap again"
 

--- a/bin/sparrowdo
+++ b/bin/sparrowdo
@@ -400,15 +400,13 @@ elif [[ "$os" =~ "archlinux" ]]; then
 
   if ! which cpanm 2>/dev/null; then
     echo "installing cpanm ..."
-    curl -s -kL http://cpanmin.us/ -o /bin/cpanm
-    chmod a+x /bin/cpanm
+    pacman -S --noconfirm -q cpanminus
   fi
 
   if ! which sparrow 2>/dev/null; then
 
     pacman -Sy
 
-    pacman -S --noconfirm -q guile
 
     if ! which perl 2>/dev/null; then
       pacman -S --noconfirm -q perl
@@ -421,6 +419,8 @@ elif [[ "$os" =~ "archlinux" ]]; then
     if ! which make 2>/dev/null; then
       pacman -S --noconfirm -q make 
     fi
+
+    pacman -S --noconfirm -q guile perl-clone perl-config-tiny perl-yaml perl-test-yaml perl-test-base perl-spiffy perl-algorithm-diff perl-text-diff perl-json perl-try-tiny perl-capture-tiny perl-file-sharedir perl-file-sharedir-install perl-module-build-tiny perl-extutils-installpaths perl-extutils-config perl-extutils-helpers perl-class-inspector
 
     cpanm -q Outthentic Sparrow || echo "Some error occurs. Try to take the system upgrade of your server: run 'pacman -Syu' on the target machine and then run bootstrap again"
 


### PR DESCRIPTION
Заменил часть модулей на нативные пакеты. Вот список модулей, которые удалось найти.
```
perl-clone
perl-config-tiny
perl-yaml
perl-test-yaml
perl-test-base
perl-spiffy
perl-algorithm-diff
perl-text-diff
perl-json
cpanminus
perl-try-tiny
perl-capture-tiny
perl-file-sharedir
perl-file-sharedir-install
perl-module-build-tiny
perl-extutils-installpaths
perl-extutils-config
perl-extutils-helpers
perl-class-inspector

```

Шибко быстро не стало, 1~3 минуты возможно. Очень сильно зависит от сети.
Старый бутстрап
https://gist.github.com/Spigell/8a689c5c5a9e0b325f84a4d5454c9f1e

Новый - https://gist.github.com/Spigell/59cdc22b203ce712398d01fc8bb3554b