### PR TITLE
bootrap: fix for archlinux database sync

### DIFF
--- a/bin/sparrowdo
+++ b/bin/sparrowdo
@@ -392,6 +392,8 @@ elif [[ "$os" =~ "centos" ]]; then
 
 elif [[ "$os" =~ "archlinux" ]]; then
 
+  pacman -Sy
+
   echo bootstrap for archlinux
 
   if ! which curl 2>/dev/null; then
@@ -404,8 +406,6 @@ elif [[ "$os" =~ "archlinux" ]]; then
   fi
 
   if ! which sparrow 2>/dev/null; then
-
-    pacman -Sy
 
     pacman -S --noconfirm -q guile 
 


### PR DESCRIPTION
Здравствуйте. Поставил pacman -Sy на самый вверх потому что в некоторых случаях, если базы нет, то на установку curl или cpanminus будет выдаваться ошибка. Этот коммит ничего не должен сломать.