### PR TITLE
password support for sparrowdo

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ An assumption is made that ssh user you run `sparrowdo` with ( see --ssh_user co
 * ssh passwordless access on the remote host
 * sudo (passwordless?) rights on remote host
 
+*NOTE* 
+You can use password authentication with --password command line parameter or ( more preferred) via shell environment $SSHPASS. See --password parameter below.
+   
+
 # Advanced usage
 
 ## Running private plugins
@@ -219,6 +223,14 @@ Sets https\_proxy environment variable on the remote host.
 ## --ssh\_user
 
 Sets user for the ssh connection to the remote host.
+
+## --password
+
+Your password for authentication to the remote host. Also you can use shell environment var #SSHPASS, e.g:
+
+    $ export SSHPASS=12345; sparrowdo ...
+
+You must install `sshpass` for using this feature.
 
 ## --ssh\_private\_key
 
@@ -488,6 +500,7 @@ This is the list of arguments valid for the input\_params function:
     Cwd
     LocalMode
     SparrowhubApi
+    Password
 
 See also the [sparrowdo client command line parameters](#sparrowdo-client-command-line-parameters) section.
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ An assumption is made that ssh user you run `sparrowdo` with ( see --ssh_user co
 * ssh passwordless access on the remote host
 * sudo (passwordless?) rights on remote host
 
-*NOTE* 
-You can use password authentication with --password command line parameter or ( more preferred) via shell environment $SSHPASS. See --password parameter below.
+***NOTE!***
+
+You can use password authentication with --password command line parameter or ( more preferred) via shell environment `SSHPASS`. See info for `--password` parameter below.
    
 
 # Advanced usage
@@ -226,11 +227,11 @@ Sets user for the ssh connection to the remote host.
 
 ## --password
 
-Your password for authentication to the remote host. Also you can use shell environment var #SSHPASS, e.g:
+Your password for authentication to the remote host. Also you can use shell environment variable `SSHPASS`, e.g:
 
     $ export SSHPASS=12345; sparrowdo ...
 
-You must install `sshpass` for using this feature.
+You must install `sshpass` to use this feature.
 
 ## --ssh\_private\_key
 

--- a/bin/sparrowdo
+++ b/bin/sparrowdo
@@ -37,6 +37,8 @@ sub MAIN (
   Str  :$sparrow_root = '/opt/sparrow', 
   Str  :$repo,
   Bool :$local_mode = False,
+  Bool :$use_sshpass = True,
+  Str  :$password,
   Str  :$docker,
   Str  :$cwd, 
   Str  :$format, 
@@ -85,9 +87,12 @@ sub MAIN (
     NoIndexUpdate => $no_index_update_val,
     SparrowRoot => $sparrow_root,
     Repo => $repo_val,
-    SparrowhubApi => $conf-ini<sparrowdo><sparrowhub_api>
+    SparrowhubApi => $conf-ini<sparrowdo><sparrowhub_api>,
+    Password => $password,
+    UseSshpass => $use_sshpass
   );
 
+  %*ENV<SSHPASS> = input_params('Password') if input_params('Password');
 
   ssh_shell "rm -rf $sparrow_root/sparrowdo-cache && mkdir -m 777 -p $sparrow_root/sparrowdo-cache";
 
@@ -239,6 +244,8 @@ sub ssh_shell ( $cmd ) {
     $ssh_host_term = input_params('SshUser') ~ '@' ~ $ssh_host_term if input_params('SshUser');
   
     $ssh_cmd  =  'ssh -o ConnectionAttempts=1  -o ConnectTimeout=5';
+
+    $ssh_cmd = 'sshpass -e' ~ ' ' ~ $ssh_cmd if %*ENV<SSHPASS>;
   
     $ssh_cmd ~= ' -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -tt';
   
@@ -313,6 +320,8 @@ our sub _scp ( $file, $dest, $reverse = 0, $recursive = 0 ) {
     $scp_params ~= ' -r ' if $recursive;
   
     $scp_command = 'scp -o ConnectionAttempts=1 -o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ' ~ $scp_params;
+
+    $scp_command = 'sshpass -e' ~ ' ' ~ $scp_command if %*ENV<SSHPASS>;
   
     if $reverse {
       $scp_command ~= ' ' ~ $ssh_host_term ~ ':' ~ $file ~ ' ' ~ $dest ;


### PR DESCRIPTION
Здравствуйте. Добавил поддержку парольной аутентификации через sshpass. 
Остановился на получении пароля через
1) ключ --password
2) Переменную окружения шела

Мне показалось, что так проще ( не надо делать файлик) и более-менее безопасно.
В целом лучше использовать SSHPASS переменную, чем ключ, так как его не будет видно в cmd
```
root     17208 36.7 15.2 691920 155020 pts/0   Sl+  01:25   0:01 /opt/rakudo/bin/   moar --execname=/opt/rakudo/bin//perl6 --libpath=/opt/rakudo/share/nqp/lib --libpath=/opt/rakudo/share/nqp/lib --libpath=/opt/rakudo/share/perl6/lib --libpath=/ opt/rakudo/share/perl6/runtime /opt/rakudo/share/perl6/runtime/perl6.moarvm /opt/   rakudo/share/perl6/site/bin/sparrowdo --host=127.0.0.1 --verbose --ssh_user=vagrant --password=vagrant
```
Добавил ключ --use_sshpass, но его нигде не использовал. Не очень понимаю, зачем он нужен. 

Я проверял на centos7 и archlinux. sshpass должен быть уже поставлен.