### PR TITLE
copy-local-file may copy directories also

### DIFF
--- a/bin/sparrowdo
+++ b/bin/sparrowdo
@@ -314,7 +314,7 @@ our sub _copy-local-file ( $file, $dest ) {
   say input_params('NoColor') ??
   "copy local file $file to remote $dest" !!
   colored("copy local file $file to remote $dest", 'bold yellow');
-  _scp($file,$dest);
+  _scp($file,$dest,0,1);
 
 }
 


### PR DESCRIPTION
Здравствуйте. Минорное изменение. Добавляет флаг -r в scp команду при вызове copy-local-file.  На копирование обычных файлов повлиять не должно. Удобно, когда нужно скопировать целую папку. Например,
```

copy-local-file './cookbooks','/tmp';
copy-local-file './roles','/tmp';

module_run 'Chef::Client', %(
    run-list => [
      "recipe[common]"
    ],
    log-level => 'info',
    force-formatter => True,
    local-mode => True,
    chef-repo-path => '/tmp'
);
```
