### PR TITLE
git-scm may acept ssh key

### DIFF
--- a/core-dsl.md
+++ b/core-dsl.md
@@ -392,6 +392,9 @@ Examples:
     directory '/tmp/foo';
     git-scm 'https://github.com/melezhik/sparrow.git', %( to => '/tmp/foo' );
 
+    # Specify ssh key for authentification
+    git-scm 'ssh://git@github.com/melezhik/sparrow.git', %( to => '/tmp/foo', ssh-key => '/tmp/my.key' );
+
     # checkout under user
     git-scm 'https://github.com/melezhik/sparrow.git', %( to => '/tmp/foo', user => 'alexey' );
 

--- a/lib/Sparrowdo/Core/DSL/Git.pm6
+++ b/lib/Sparrowdo/Core/DSL/Git.pm6
@@ -14,6 +14,7 @@ multi sub git-scm ( $source, %args? ) is export {
   %bash-args<description> = "git checkout $source";
   %bash-args<user> = %args<user> if %args<user>;
   %bash-args<debug> = 1 if %args<debug>;
+  %bash-args<envvars><GIT_SSH_COMMAND> = qq ("ssh -i %args<ssh_key>" ) if %args<ssh_key>;
 
   bash qq:to/HERE/, %bash-args;
     set -e;


### PR DESCRIPTION
Здравствуйте. git-scm теперь может принимать ssh ключ для клонирования/апдейта репозиториев по ssh. Пример, которым проверял:
```
directory-delete '/tmp/sparrowdo';
directory '/tmp/sparrowdo';

copy-local-file '/home/spigell/.ssh/keys/spigell.key', '/tmp/my.key';

git-scm 'git@github.com:Spigell/sparrowdo.git', %(
  to => '/tmp/sparrowdo',
  ssh_key => '/tmp/my.key',
  debug => '1'
);


```
Не уверен, что так правильно делать хеш внутри хеша. 